### PR TITLE
feat: Add UI options

### DIFF
--- a/monster-hunter-rise-overlay.lua
+++ b/monster-hunter-rise-overlay.lua
@@ -331,6 +331,10 @@ re.on_draw_ui(function()
     if string.len(status) > 0 then
         imgui.text("[monster_has_hp_bar.lua] Status: " .. status);
     end
+
+    _, monster_UI.enabled = imgui.checkbox("Enable monster health UI", monster_UI.enabled)
+    _, time_UI.enabled = imgui.checkbox("Enable quest time UI", time_UI.enabled)
+    _, damage_meter_UI.enabled = imgui.checkbox("Enable damage dealt UI", damage_meter_UI.enabled)
 end);
 
 re.on_frame(function()


### PR DESCRIPTION
Hi @GreenComfyTea , thanks for your great effort to bring this amazing mod. I would like to add some features to improve this mod. I try to add the UI options in the REFramework menu so that we can simply enable UI with a checkbox in-game. It will look like this:
![20220119015839_1](https://user-images.githubusercontent.com/13619684/149994093-090fcd71-3d4d-494e-b80f-07af6316de1f.jpg)
![20220119015841_1](https://user-images.githubusercontent.com/13619684/149994112-805b5636-2516-4be2-9b66-3f829a84c4f6.jpg)

I think it can be an easy way to manage the UI rather than edit the script all the time. What do you think about this idea?
