### PR TITLE
feat: Add capture health hint

### DIFF
--- a/MHR_Overlay.lua
+++ b/MHR_Overlay.lua
@@ -76,7 +76,8 @@ local monster_UI = {
     colors = {
 		health_bar = {
             remaining_health = 0xB952A674,
-            missing_health = 0xB9000000
+            missing_health = 0xB9000000,
+            capturable_health = 0xFF7373ff
         },
 
         monster_name = {
@@ -321,7 +322,6 @@ re.on_frame(function()
 		damage_meter();
 	end
 
-	draw.text("x:\n" .. tostring(x), 500, 800, 0xFFFFFFFF);
 end);
 
 function get_window_size()
@@ -404,6 +404,7 @@ function record_health(enemy)
     local health = vital_param:call("get_Current");
     local max_health = vital_param:call("get_Max");
 	local missing_health = max_health - health;
+	local capture_health = physical_param:call("get_CaptureHpVital");
 
 	local health_percentage = 1;
 	if max_health ~= 0 then
@@ -437,6 +438,8 @@ function record_health(enemy)
     monster.max_health = max_health;
 	monster.health_percentage = health_percentage;
 	monster.missing_health = missing_health;
+	monster.capture_health = capture_health;
+
 end
 
 function monster_health()
@@ -517,7 +520,13 @@ function monster_health()
 			local health_bar_missing_health_width = monster_UI.health_bar.width - health_bar_remaining_health_width;
 
 			--remaining health
-			draw.filled_rect(screen_position.x + monster_UI.offsets.health_bar.x, screen_position.y + monster_UI.offsets.health_bar.y, health_bar_remaining_health_width, monster_UI.health_bar.height, monster_UI.colors.health_bar.remaining_health);
+			if monster.health <= monster.capture_health then
+				remaining_health_color = monster_UI.colors.health_bar.capturable_health
+			else
+				remaining_health_color = monster_UI.colors.health_bar.remaining_health
+			end
+
+			draw.filled_rect(screen_position.x + monster_UI.offsets.health_bar.x, screen_position.y + monster_UI.offsets.health_bar.y, health_bar_remaining_health_width, monster_UI.health_bar.height, remaining_health_color);
 			--missing health
 			draw.filled_rect(screen_position.x + monster_UI.offsets.health_bar.x + health_bar_remaining_health_width, screen_position.y + monster_UI.offsets.health_bar.y, health_bar_missing_health_width, monster_UI.health_bar.height, monster_UI.colors.health_bar.missing_health);
 		end


### PR DESCRIPTION
Hi @GreenComfyTea , I made some changes so that we can identify the monster health is lower enough to be captured. I think it will be helpful for hunters. 👍 
![image](https://user-images.githubusercontent.com/13619684/150833677-d9278952-c2ed-4c7f-a4a5-3a7a3c25c2cd.png)
![image](https://user-images.githubusercontent.com/13619684/150833751-a182e179-00a6-4c87-add4-efafc1f2cb20.png)

BTW, I also found an [unnecessary line](https://github.com/GreenComfyTea/monster-hunter-rise-overlay/blob/9c44d3ce060c47254671cfa9f38bfa869987e114/MHR_Overlay.lua#L324) that draws unexpected text on the screen, just delete it. Let me know if you want to keep it.